### PR TITLE
feature/OT207-77 Endpoint Actualización Comentarios

### DIFF
--- a/src/main/java/com/alkemy/ong/controller/CommentaryController.java
+++ b/src/main/java/com/alkemy/ong/controller/CommentaryController.java
@@ -1,15 +1,20 @@
 package com.alkemy.ong.controller;
 
-import com.alkemy.ong.auth.service.impl.UserDetailsCustomService;
 import com.alkemy.ong.dto.CommentaryBodyDTO;
+import com.alkemy.ong.dto.CommentaryDTO;
+import com.alkemy.ong.exception.BadRequestException;
 import com.alkemy.ong.service.ICommentaryService;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 
 @RestController
 @RequestMapping("/comments")
@@ -17,11 +22,19 @@ public class CommentaryController {
     
     @Autowired
     private ICommentaryService commentaryService;
-    
+
     @GetMapping
     public ResponseEntity<List<CommentaryBodyDTO>> getComments () {
         List<CommentaryBodyDTO> listDto = commentaryService.getCommentaries();
         return ResponseEntity.ok().body(listDto);
+    }
+    @PutMapping("/{id}")
+    public ResponseEntity<CommentaryBodyDTO> updateCommentary(@Valid @RequestBody CommentaryBodyDTO dto, BindingResult bindingResult,
+                                                           @PathVariable Long id , HttpServletRequest request) {
+        if (bindingResult.hasErrors()) {
+            throw new BadRequestException(bindingResult);
+        }
+        return new ResponseEntity<>(commentaryService.update(id, dto ,request), HttpStatus.CREATED);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/alkemy/ong/mapper/CommentaryMapper.java
+++ b/src/main/java/com/alkemy/ong/mapper/CommentaryMapper.java
@@ -2,7 +2,9 @@ package com.alkemy.ong.mapper;
 
 import com.alkemy.ong.dto.CommentaryBodyDTO;
 import com.alkemy.ong.dto.CommentaryDTO;
+import com.alkemy.ong.dto.TestimonialDTO;
 import com.alkemy.ong.model.Commentary;
+import com.alkemy.ong.model.Testimonial;
 import com.alkemy.ong.repository.CommentaryRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,5 +42,9 @@ public class CommentaryMapper {
         List<CommentaryBodyDTO> DtoList = new ArrayList();
         entityList.forEach(entity -> DtoList.add(commentaryEntityBodyToDTO(entity)));
         return DtoList;
+    }
+
+    public void entityCommentaryRefreshValues(Commentary entity, CommentaryBodyDTO dto){
+        entity.setBody(dto.getBody());
     }
 }

--- a/src/main/java/com/alkemy/ong/service/ICommentaryService.java
+++ b/src/main/java/com/alkemy/ong/service/ICommentaryService.java
@@ -1,8 +1,8 @@
 package com.alkemy.ong.service;
 
-import com.alkemy.ong.auth.dto.UserResponseDto;
 import com.alkemy.ong.dto.CommentaryBodyDTO;
 import com.alkemy.ong.dto.CommentaryDTO;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -13,6 +13,10 @@ public interface ICommentaryService{
     
     List<CommentaryBodyDTO> getCommentaries();
 
+    @Transactional
+    CommentaryBodyDTO update(Long id, CommentaryBodyDTO dto, HttpServletRequest request);
+
     void deleteById(Long id, HttpServletRequest request);
+
 
 }

--- a/src/main/java/com/alkemy/ong/service/impl/CommentaryServiceImpl.java
+++ b/src/main/java/com/alkemy/ong/service/impl/CommentaryServiceImpl.java
@@ -5,16 +5,23 @@ import com.alkemy.ong.auth.repository.UserRepository;
 import com.alkemy.ong.auth.service.impl.UserDetailsCustomService;
 import com.alkemy.ong.dto.CommentaryBodyDTO;
 import com.alkemy.ong.dto.CommentaryDTO;
+import com.alkemy.ong.dto.TestimonialDTO;
 import com.alkemy.ong.exception.ForbiddenException;
 import com.alkemy.ong.exception.NotFoundException;
+import com.alkemy.ong.exception.UnauthorizedException;
 import com.alkemy.ong.mapper.CommentaryMapper;
 import com.alkemy.ong.model.Commentary;
 import com.alkemy.ong.model.Role;
+import com.alkemy.ong.model.Testimonial;
 import com.alkemy.ong.model.UserEntity;
 import com.alkemy.ong.repository.CommentaryRepository;
 import com.alkemy.ong.service.ICommentaryService;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -52,6 +59,26 @@ public class CommentaryServiceImpl implements ICommentaryService {
         }
         List<CommentaryBodyDTO> dtoList = mapper.entityListToDtoList(entityList);
         return dtoList;
+    }
+
+    @Override
+    @Transactional
+    public CommentaryBodyDTO update(Long id, CommentaryBodyDTO dto, HttpServletRequest request) {
+        Optional<Commentary> entity = this.commentaryRepository.findById(id);
+        if (entity.isEmpty()) {
+            throw new NotFoundException("Commentary id does not exist");
+        }
+        Commentary commentary = commentaryRepository.findById(id).orElseThrow(() -> new NotFoundException(ID_NOT_FOUND + id));
+        UserResponseDto responseDto = userDetailsCustomService.getProfile(request);
+        UserEntity user = userRepository.findByEmail(responseDto.getEmail()).get();
+        if (user.getId() == commentary.getUserEntity().getId() || request.isUserInRole("ROLE_ADMIN")) {
+            this.mapper.entityCommentaryRefreshValues(entity.get(), dto);
+            Commentary result = this.commentaryRepository.save(entity.get());
+            return this.mapper.commentaryEntityBodyToDTO(result);
+        } else {
+            throw new ForbiddenException("User with no access.");
+        }
+
     }
     @Transactional
     @Override


### PR DESCRIPTION
COMO usuario
QUIERO actualizar un comentario propio
PARA mantener la información actualizada

Criterios de aceptación:
PUT /comments/:id - Deberá validar la existencia del comentario en base a su id. Solamente podrán editar un comentario el usuario que lo realizó o un administrador. Deberá devolver un código de error 404 si el comentario no existe, o 403 si no tiene permiso para modificarlo.